### PR TITLE
Use a different provider to manage CRDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13 |
 | <a name="requirement_helm"></a> [helm](#requirement\_helm) | >= 1 |
+| <a name="requirement_http"></a> [http](#requirement\_http) | >= 2.0 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | ~> 1.13 |
 
 ## Providers
 

--- a/modules/crd/README.md
+++ b/modules/crd/README.md
@@ -15,25 +15,25 @@ Helm chart into your Terraform State.
 Modify the path of your resources accordingly:
 
 ```bash
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.authservices.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=authservices.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.consulresolvers.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=consulresolvers.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.devportals.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=devportals.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.filterpolicies.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=filterpolicies.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.filters.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=filters.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.hosts.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=hosts.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.kubernetesendpointresolvers.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=kubernetesendpointresolvers.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.kubernetesserviceresolvers.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=kubernetesserviceresolvers.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.logservices.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=logservices.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.mappings.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=mappings.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.modules.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=modules.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.projectcontrollers.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=projectcontrollers.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.projectrevisions.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=projectrevisions.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.projects.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=projects.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.ratelimits.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=ratelimits.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.ratelimitservices.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=ratelimitservices.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.tcpmappings.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=tcpmappings.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.tlscontexts.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=tlscontexts.getambassador.io"
-terraform import 'module.crd.kubernetes_manifest.crds["apiextensions.k8s.io/v1.CustomResourceDefinition.default.tracingservices.getambassador.io"]' "apiVersion=apiextensions.k8s.io/v1,kind=CustomResourceDefinition,namespace=default,name=tracingservices.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/authservices.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//authservices.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/consulresolvers.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//consulresolvers.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/devportals.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//devportals.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/filterpolicies.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//filterpolicies.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/filters.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//filters.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/hosts.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//hosts.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/kubernetesendpointresolvers.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//kubernetesendpointresolvers.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/kubernetesserviceresolvers.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//kubernetesserviceresolvers.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/logservices.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//logservices.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/mappings.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//mappings.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/modules.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//modules.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/projectcontrollers.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//projectcontrollers.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/projectrevisions.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//projectrevisions.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/projects.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//projects.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/ratelimits.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//ratelimits.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/ratelimitservices.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//ratelimitservices.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/tcpmappings.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//tcpmappings.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/tlscontexts.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//tlscontexts.getambassador.io"
+terraform import 'module.crd.kubectl_manifest.manifest["/apis/apiextensions.k8s.io/v1/customresourcedefinitions/tracingservices.getambassador.io"]' "apiextensions.k8s.io/v1//CustomResourceDefinition//tracingservices.getambassador.io"
 ```
 
 Note that the 1.x Helm charts created CRDs that are only used in AES and these will be imported and
@@ -46,14 +46,14 @@ Ingress.
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15 |
 | <a name="requirement_http"></a> [http](#requirement\_http) | >= 2.0 |
-| <a name="requirement_kubernetes"></a> [kubernetes](#requirement\_kubernetes) | >= 2.6 |
+| <a name="requirement_kubectl"></a> [kubectl](#requirement\_kubectl) | >= 1.13 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_http"></a> [http](#provider\_http) | >= 2.0 |
-| <a name="provider_kubernetes"></a> [kubernetes](#provider\_kubernetes) | >= 2.6 |
+| <a name="provider_kubectl"></a> [kubectl](#provider\_kubectl) | >= 1.13 |
 
 ## Modules
 
@@ -63,8 +63,9 @@ No modules.
 
 | Name | Type |
 |------|------|
-| [kubernetes_manifest.crds](https://registry.terraform.io/providers/hashicorp/kubernetes/latest/docs/resources/manifest) | resource |
+| [kubectl_manifest.manifest](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/resources/manifest) | resource |
 | [http_http.manifest](https://registry.terraform.io/providers/hashicorp/http/latest/docs/data-sources/http) | data source |
+| [kubectl_file_documents.manifest](https://registry.terraform.io/providers/gavinbunney/kubectl/latest/docs/data-sources/file_documents) | data source |
 
 ## Inputs
 

--- a/modules/crd/main.tf
+++ b/modules/crd/main.tf
@@ -9,7 +9,7 @@ data "kubectl_file_documents" "manifest" {
 }
 
 resource "kubectl_manifest" "manifest" {
-    for_each = data.kubectl_file_documents.manifest.manifests
+  for_each = data.kubectl_file_documents.manifest.manifests
 
-    yaml_body = each.value
+  yaml_body = each.value
 }

--- a/modules/crd/outputs.tf
+++ b/modules/crd/outputs.tf
@@ -1,4 +1,4 @@
 output "resources" {
   description = "List of resources created"
-  value       = keys(local.manifest)
+  value       = keys(data.kubectl_file_documents.manifest.manifests)
 }

--- a/modules/crd/versions.tf
+++ b/modules/crd/versions.tf
@@ -2,9 +2,9 @@ terraform {
   required_version = ">= 0.15"
 
   required_providers {
-    kubernetes = {
-      source  = "hashicorp/kubernetes"
-      version = ">= 2.6"
+    kubectl = {
+      source = "gavinbunney/kubectl"
+      version = ">= 1.13"
     }
     http = {
       source  = "hashicorp/http"

--- a/modules/crd/versions.tf
+++ b/modules/crd/versions.tf
@@ -3,7 +3,7 @@ terraform {
 
   required_providers {
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
       version = ">= 1.13"
     }
     http = {

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,13 @@ terraform {
       source  = "hashicorp/helm"
       version = ">= 1"
     }
+    kubectl = {
+      source = "gavinbunney/kubectl"
+      version = "~> 1.13"
+    }
+    http = {
+      source  = "hashicorp/http"
+      version = ">= 2.0"
+    }
   }
 }

--- a/versions.tf
+++ b/versions.tf
@@ -7,7 +7,7 @@ terraform {
       version = ">= 1"
     }
     kubectl = {
-      source = "gavinbunney/kubectl"
+      source  = "gavinbunney/kubectl"
       version = "~> 1.13"
     }
     http = {


### PR DESCRIPTION
`kubernetes_manifest` had several issues:

- Does not take care of dependencies. For e.g. `Namespace` need to be
created first
- Had inconsistent apply issues when it tried to parse the YAML returned
from the server into its state

The `kubectl` provider tries to do less and is simpler.

- This one behaves like `kubectl apply`
- So will take care of dependency order.
